### PR TITLE
feat: display weekly reset as day and time like Anthropic dashboard

### DIFF
--- a/src/components/UsageView.tsx
+++ b/src/components/UsageView.tsx
@@ -8,6 +8,7 @@ import {
   getWeeklyGlow,
   computeFill,
   formatResetTime,
+  formatWeeklyResetTime,
 } from "../utils";
 
 interface UsageViewProps {
@@ -23,9 +24,10 @@ interface UsageBarProps {
   glow: string;
   displayMode: DisplayMode;
   reset: string | null;
+  resetPrefix?: string;
 }
 
-function UsageBar({ label, fill, color, glow, displayMode, reset }: UsageBarProps) {
+function UsageBar({ label, fill, color, glow, displayMode, reset, resetPrefix = "in " }: UsageBarProps) {
   return (
     <div className="panel-bar-group">
       <div className="panel-bar-label-row">
@@ -44,7 +46,7 @@ function UsageBar({ label, fill, color, glow, displayMode, reset }: UsageBarProp
           }}
         />
       </div>
-      {reset && <span className="panel-bar-reset">Resets in {reset}</span>}
+      {reset && <span className="panel-bar-reset">Resets {resetPrefix}{reset}</span>}
     </div>
   );
 }
@@ -83,7 +85,8 @@ export function UsageView({ data, displayMode, onDisconnect }: UsageViewProps) {
           color={getWeeklyColor(weeklyPercent)}
           glow={getWeeklyGlow(weeklyPercent)}
           displayMode={displayMode}
-          reset={formatResetTime(data.weeklyReset)}
+          reset={formatWeeklyResetTime(data.weeklyReset)}
+          resetPrefix=""
         />
 
         {data.extraUsageSpend != null && (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,3 +50,19 @@ export function formatResetTime(isoString: string | null): string | null {
     return null;
   }
 }
+
+export function formatWeeklyResetTime(isoString: string | null): string | null {
+  if (!isoString) return null;
+  try {
+    const resetDate = new Date(isoString);
+    const day = resetDate.toLocaleDateString(undefined, { weekday: "short" });
+    const time = resetDate.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+    return `${day} ${time}`;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Change weekly limit reset display from relative hours format (e.g. '3h 45m') to absolute day+time format (e.g. 'Fri 10:00 AM'), matching the Anthropic dashboard.

Closes #8

Generated with [Claude Code](https://claude.ai/code)