### PR TITLE
fix: show "-" in tray title when disconnected

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -41,11 +41,14 @@ pub(crate) fn has_token() -> bool {
 #[tauri::command]
 pub(crate) fn clear_token(
     poller_state: tauri::State<'_, Mutex<Option<PollerHandle>>>,
+    tray_state: tauri::State<'_, Mutex<TrayState>>,
 ) -> Result<(), String> {
     // Stop the background poller before clearing credentials
     if let Some(handle) = poller_state.lock().unwrap().take() {
         handle.stop();
     }
+    // Reset tray title to "-" to indicate disconnected state
+    let _ = tray_state.lock().unwrap().0.set_title(Some("-"));
     delete_keychain_oauth_blob()
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,12 +137,12 @@ function App() {
   // Handle disconnect
   const handleDisconnect = async () => {
     try {
-      // clear_token also stops the backend poller and clears the tray title
+      // clear_token also stops the backend poller
       await invoke("clear_token");
     } catch {
       // ignore
     }
-    await invoke("update_tray_title", { title: null }).catch(() => {});
+    await invoke("update_tray_title", { title: "-" }).catch(() => {});
     setClaudeUsage(null);
     setError(null);
     setMode("setup");


### PR DESCRIPTION
When the user disconnects, the tray title now shows "-" instead of retaining the old usage percentage.

Fixes #7

Generated with [Claude Code](https://claude.ai/code)