### PR TITLE
feat: display last updated at under extra usage

### DIFF
--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -12,6 +12,7 @@ pub struct ClaudeUsageData {
     pub plan_type: Option<String>,
     pub extra_usage_spend: Option<f64>,
     pub extra_usage_limit: Option<f64>,
+    pub last_updated: Option<u64>,
 }
 
 // --- Settings ---

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -308,6 +308,11 @@ pub(crate) async fn fetch_claude_usage_impl() -> Result<ClaudeUsageData, String>
         _ => None,
     };
 
+    let last_updated = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_millis() as u64);
+
     Ok(ClaudeUsageData {
         session_percent_used: clamp_percent(session_percent_used),
         weekly_percent_used: clamp_percent(weekly_percent_used),
@@ -316,6 +321,7 @@ pub(crate) async fn fetch_claude_usage_impl() -> Result<ClaudeUsageData, String>
         plan_type,
         extra_usage_spend,
         extra_usage_limit,
+        last_updated,
     })
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -231,6 +231,14 @@ body,
   color: rgba(255, 255, 255, 0.85);
 }
 
+.panel-last-updated {
+  margin: 0;
+  text-align: center;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.35);
+  font-family: "SF Mono", "Menlo", "Monaco", monospace;
+}
+
 /* ---------------------------------------------------------------------------
    Open usage link button
 --------------------------------------------------------------------------- */

--- a/src/__mocks__/tauri-api-core.ts
+++ b/src/__mocks__/tauri-api-core.ts
@@ -15,6 +15,7 @@ const defaultHandler: InvokeHandler = (cmd) => {
         planType: "Pro",
         extraUsageSpend: null,
         extraUsageLimit: null,
+        lastUpdated: Date.now(),
       };
     case "save_poll_interval":
     case "clear_token":

--- a/src/components/UsageView.stories.tsx
+++ b/src/components/UsageView.stories.tsx
@@ -16,6 +16,7 @@ const baseData: ClaudeUsageData = {
   planType: "Pro",
   extraUsageSpend: null,
   extraUsageLimit: null,
+  lastUpdated: Date.now(),
 };
 
 const meta: Meta<typeof UsageView> = {

--- a/src/components/UsageView.tsx
+++ b/src/components/UsageView.tsx
@@ -9,6 +9,7 @@ import {
   computeFill,
   formatResetTime,
   formatWeeklyResetTime,
+  formatLastUpdated,
 } from "../utils";
 
 interface UsageViewProps {
@@ -99,6 +100,12 @@ export function UsageView({ data, displayMode, onDisconnect }: UsageViewProps) {
               )}
             </span>
           </div>
+        )}
+
+        {formatLastUpdated(data.lastUpdated) && (
+          <p className="panel-last-updated">
+            Updated at {formatLastUpdated(data.lastUpdated)}
+          </p>
         )}
       </div>
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export interface ClaudeUsageData {
   planType: string | null;
   extraUsageSpend: number | null;
   extraUsageLimit: number | null;
+  lastUpdated: number | null;
 }
 
 export type DisplayMode = "usage" | "remaining";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,20 @@ export function formatResetTime(isoString: string | null): string | null {
   }
 }
 
+export function formatLastUpdated(timestamp: number | null): string | null {
+  if (!timestamp) return null;
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+  } catch {
+    return null;
+  }
+}
+
 export function formatWeeklyResetTime(isoString: string | null): string | null {
   if (!isoString) return null;
   try {


### PR DESCRIPTION
Adds a "Updated at HH:MM AM/PM" timestamp below the extra usage section in the usage panel, centered, showing when data was last fetched from the API.

Closes #10

Generated with [Claude Code](https://claude.ai/code)