### PR TITLE
feat: implement rate limit handling (HTTP 429) with exponential backoff and jitter

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -16,7 +16,7 @@ use crate::usage::fetch_claude_usage_impl;
 
 #[tauri::command]
 pub(crate) async fn fetch_claude_usage() -> Result<ClaudeUsageData, String> {
-    fetch_claude_usage_impl().await
+    fetch_claude_usage_impl().await.map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/src-tauri/src/poller.rs
+++ b/src-tauri/src/poller.rs
@@ -1,6 +1,7 @@
 use std::sync::Mutex;
 use std::time::Duration;
 
+use rand::Rng;
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::watch;
 use tokio::time::{self, MissedTickBehavior};
@@ -9,7 +10,7 @@ use tauri::async_runtime;
 
 use crate::models::{ClaudeUsageData, Settings};
 use crate::tray::TrayState;
-use crate::usage::fetch_claude_usage_impl;
+use crate::usage::{fetch_claude_usage_impl, FetchError};
 
 /// Handle to control the background polling loop.
 /// Stored as `Mutex<Option<PollerHandle>>` in Tauri managed state.
@@ -29,6 +30,14 @@ impl PollerHandle {
 }
 
 const MAX_BACKOFF_SECS: u64 = 900; // 15 minutes
+const RATE_LIMIT_INITIAL_BACKOFF_SECS: u64 = 30;
+const MAX_RATE_LIMIT_BACKOFF_SECS: u64 = 600; // 10 minutes
+
+enum PollOutcome {
+    Success,
+    RateLimit { retry_after_secs: Option<u64> },
+    Error,
+}
 
 /// Spawn the background polling task. Returns a handle to control it.
 pub(crate) fn start_poller(app_handle: AppHandle, initial_interval_secs: u64) -> PollerHandle {
@@ -40,38 +49,88 @@ pub(crate) fn start_poller(app_handle: AppHandle, initial_interval_secs: u64) ->
             initial_interval_secs
         );
 
-        // Initial fetch right away
-        do_poll(&app_handle).await;
-
         let mut base_interval_secs = initial_interval_secs;
-        let mut interval = time::interval(Duration::from_secs(base_interval_secs));
+        let mut consecutive_failures: u32 = 0;
+        let mut rate_limit_failures: u32 = 0;
+        let mut is_rate_limited = false;
+
+        // Initial fetch right away
+        let initial_outcome = do_poll(&app_handle).await;
+        let mut interval = match initial_outcome {
+            PollOutcome::RateLimit { retry_after_secs } => {
+                is_rate_limited = true;
+                rate_limit_failures = 1;
+                let secs = retry_after_secs.unwrap_or(RATE_LIMIT_INITIAL_BACKOFF_SECS);
+                let _ = app_handle.emit(
+                    "rate-limited",
+                    serde_json::json!({ "retryAfterSecs": secs }),
+                );
+                time::interval(Duration::from_secs(secs))
+            }
+            _ => time::interval(Duration::from_secs(base_interval_secs)),
+        };
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         interval.tick().await; // consume immediate first tick
-
-        let mut consecutive_failures: u32 = 0;
 
         loop {
             tokio::select! {
                 _ = interval.tick() => {
-                    let ok = do_poll(&app_handle).await;
-                    if ok {
-                        consecutive_failures = 0;
-                        // Restore normal interval if we were in backoff
-                        if interval.period() != Duration::from_secs(base_interval_secs) {
-                            interval = time::interval(Duration::from_secs(base_interval_secs));
+                    match do_poll(&app_handle).await {
+                        PollOutcome::Success => {
+                            consecutive_failures = 0;
+                            if is_rate_limited {
+                                is_rate_limited = false;
+                                rate_limit_failures = 0;
+                                let _ = app_handle.emit("rate-limit-cleared", ());
+                                println!("[claude-usage] Rate limit cleared, resuming normal polling");
+                            }
+                            // Restore normal interval if we were in backoff
+                            if interval.period() != Duration::from_secs(base_interval_secs) {
+                                interval = time::interval(Duration::from_secs(base_interval_secs));
+                                interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                                interval.tick().await;
+                            }
+                        }
+                        PollOutcome::RateLimit { retry_after_secs } => {
+                            is_rate_limited = true;
+                            rate_limit_failures += 1;
+                            let backoff_secs = if let Some(secs) = retry_after_secs {
+                                println!("[claude-usage] Rate limited. Respecting Retry-After: {}s", secs);
+                                secs
+                            } else {
+                                // Exponential backoff with jitter starting at RATE_LIMIT_INITIAL_BACKOFF_SECS
+                                let exp_backoff = (RATE_LIMIT_INITIAL_BACKOFF_SECS
+                                    * 2u64.pow(rate_limit_failures.saturating_sub(1).min(5)))
+                                .min(MAX_RATE_LIMIT_BACKOFF_SECS);
+                                let max_jitter = (exp_backoff / 4).max(1);
+                                let jitter: u64 = rand::rng().random_range(0..=max_jitter);
+                                let total = exp_backoff + jitter;
+                                println!(
+                                    "[claude-usage] Rate limited (failure #{}). Backing off {}s (base={}s, jitter={}s)",
+                                    rate_limit_failures, total, exp_backoff, jitter
+                                );
+                                total
+                            };
+                            let _ = app_handle.emit(
+                                "rate-limited",
+                                serde_json::json!({ "retryAfterSecs": backoff_secs }),
+                            );
+                            interval = time::interval(Duration::from_secs(backoff_secs));
                             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
                             interval.tick().await;
                         }
-                    } else {
-                        consecutive_failures += 1;
-                        if consecutive_failures > 1 {
-                            let backoff_secs = (base_interval_secs
-                                * 2u64.pow(consecutive_failures.min(6) - 1))
-                            .min(MAX_BACKOFF_SECS);
-                            println!("[claude-usage] Backing off to {}s", backoff_secs);
-                            interval = time::interval(Duration::from_secs(backoff_secs));
-                            interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-                            interval.tick().await; // consume immediate tick
+                        PollOutcome::Error => {
+                            is_rate_limited = false;
+                            consecutive_failures += 1;
+                            if consecutive_failures > 1 {
+                                let backoff_secs = (base_interval_secs
+                                    * 2u64.pow(consecutive_failures.min(6) - 1))
+                                .min(MAX_BACKOFF_SECS);
+                                println!("[claude-usage] Backing off to {}s", backoff_secs);
+                                interval = time::interval(Duration::from_secs(backoff_secs));
+                                interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+                                interval.tick().await; // consume immediate tick
+                            }
                         }
                     }
                 }
@@ -90,6 +149,8 @@ pub(crate) fn start_poller(app_handle: AppHandle, initial_interval_secs: u64) ->
                         Some(new_secs) => {
                             base_interval_secs = new_secs;
                             consecutive_failures = 0;
+                            rate_limit_failures = 0;
+                            is_rate_limited = false;
                             interval = time::interval(Duration::from_secs(base_interval_secs));
                             interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
                             interval.tick().await; // consume immediate tick
@@ -108,21 +169,25 @@ pub(crate) fn start_poller(app_handle: AppHandle, initial_interval_secs: u64) ->
     PollerHandle { interval_tx: tx }
 }
 
-/// Perform a single poll: fetch usage, update tray, emit event. Returns true on success.
-async fn do_poll(app_handle: &AppHandle) -> bool {
+/// Perform a single poll: fetch usage, update tray, emit event. Returns the outcome.
+async fn do_poll(app_handle: &AppHandle) -> PollOutcome {
     match fetch_claude_usage_impl().await {
         Ok(data) => {
             update_tray_title(app_handle, &data);
             let _ = app_handle.emit("usage-updated", &data);
-            true
+            PollOutcome::Success
         }
-        Err(e) => {
-            println!("[claude-usage] Poll failed: {}", e);
-            let _ = app_handle.emit(
-                "usage-error",
-                serde_json::json!({ "message": e.to_string() }),
+        Err(FetchError::RateLimit { retry_after_secs }) => {
+            println!(
+                "[claude-usage] Poll rate limited: retry_after={:?}",
+                retry_after_secs
             );
-            false
+            PollOutcome::RateLimit { retry_after_secs }
+        }
+        Err(FetchError::Other(e)) => {
+            println!("[claude-usage] Poll failed: {}", e);
+            let _ = app_handle.emit("usage-error", serde_json::json!({ "message": e }));
+            PollOutcome::Error
         }
     }
 }

--- a/src-tauri/src/usage.rs
+++ b/src-tauri/src/usage.rs
@@ -7,6 +7,35 @@ use crate::models::{
 };
 use crate::oauth::{load_claude_credentials, refresh_claude_token};
 
+#[derive(Debug)]
+pub(crate) enum FetchError {
+    RateLimit { retry_after_secs: Option<u64> },
+    Other(String),
+}
+
+impl std::fmt::Display for FetchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FetchError::RateLimit { retry_after_secs } => {
+                if let Some(secs) = retry_after_secs {
+                    write!(f, "Rate limited. Retry after {}s.", secs)
+                } else {
+                    write!(f, "Rate limited. Please try again later.")
+                }
+            }
+            FetchError::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+fn extract_retry_after(response: &reqwest::Response) -> Option<u64> {
+    response
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok())
+}
+
 pub(crate) fn plan_display_from_profile(org: &ClaudeProfileOrganization) -> Option<String> {
     let tier = org.rate_limit_tier.as_deref().unwrap_or("");
     let org_type = org.organization_type.as_deref().unwrap_or("");
@@ -136,12 +165,14 @@ fn extract_window_reset(root: &Value, keys: &[&str]) -> Option<String> {
     None
 }
 
-pub(crate) async fn fetch_claude_usage_impl() -> Result<ClaudeUsageData, String> {
-    let credentials = load_claude_credentials().await?;
+pub(crate) async fn fetch_claude_usage_impl() -> Result<ClaudeUsageData, FetchError> {
+    let credentials = load_claude_credentials()
+        .await
+        .map_err(FetchError::Other)?;
     let access_token = credentials
         .access_token
         .as_deref()
-        .ok_or_else(|| "Claude credentials are missing accessToken.".to_string())?;
+        .ok_or_else(|| FetchError::Other("Claude credentials are missing accessToken.".to_string()))?;
 
     println!(
         "[claude-usage] Fetching usage with token starting with: {}...",
@@ -157,53 +188,70 @@ pub(crate) async fn fetch_claude_usage_impl() -> Result<ClaudeUsageData, String>
         .timeout(std::time::Duration::from_secs(15))
         .send()
         .await
-        .map_err(|e| format!("Claude OAuth request failed: {}", e))?;
+        .map_err(|e| FetchError::Other(format!("Claude OAuth request failed: {}", e)))?;
 
     let initial_status = response.status();
 
     // On 401, attempt token refresh and retry once before reading the body
-    let (status, body, access_token) = if initial_status == reqwest::StatusCode::UNAUTHORIZED {
-        println!("[claude-usage] Usage API returned 401, attempting token refresh and retry...");
+    let (status, body, retry_after_secs, access_token) =
+        if initial_status == reqwest::StatusCode::UNAUTHORIZED {
+            println!(
+                "[claude-usage] Usage API returned 401, attempting token refresh and retry..."
+            );
 
-        // Discard the 401 response body
-        let _ = response.text().await;
+            // Discard the 401 response body
+            let _ = response.text().await;
 
-        let oauth_blob =
-            read_keychain_oauth_blob().map_err(|e| format!("Re-auth failed: {}", e))?;
-        let refresh_tok = oauth_blob
-            .refresh_token
-            .as_deref()
-            .ok_or_else(|| "No refresh token available for retry.".to_string())?;
-        let refreshed = refresh_claude_token(refresh_tok, &oauth_blob).await?;
-        let new_token = refreshed
-            .access_token
-            .as_deref()
-            .ok_or_else(|| "Refresh succeeded but no access token returned.".to_string())?
-            .to_string();
+            let oauth_blob = read_keychain_oauth_blob()
+                .map_err(|e| FetchError::Other(format!("Re-auth failed: {}", e)))?;
+            let refresh_tok = oauth_blob.refresh_token.as_deref().ok_or_else(|| {
+                FetchError::Other("No refresh token available for retry.".to_string())
+            })?;
+            let refreshed = refresh_claude_token(refresh_tok, &oauth_blob)
+                .await
+                .map_err(FetchError::Other)?;
+            let new_token = refreshed
+                .access_token
+                .as_deref()
+                .ok_or_else(|| {
+                    FetchError::Other(
+                        "Refresh succeeded but no access token returned.".to_string(),
+                    )
+                })?
+                .to_string();
 
-        let retry_response = client
-            .get("https://api.anthropic.com/api/oauth/usage")
-            .header("Accept", "application/json")
-            .header("Authorization", format!("Bearer {}", new_token))
-            .header("anthropic-beta", "oauth-2025-04-20")
-            .timeout(std::time::Duration::from_secs(15))
-            .send()
-            .await
-            .map_err(|e| format!("Retry request failed: {}", e))?;
+            let retry_response = client
+                .get("https://api.anthropic.com/api/oauth/usage")
+                .header("Accept", "application/json")
+                .header("Authorization", format!("Bearer {}", new_token))
+                .header("anthropic-beta", "oauth-2025-04-20")
+                .timeout(std::time::Duration::from_secs(15))
+                .send()
+                .await
+                .map_err(|e| FetchError::Other(format!("Retry request failed: {}", e)))?;
 
-        let retry_status = retry_response.status();
-        let retry_body = retry_response
-            .text()
-            .await
-            .map_err(|e| format!("Failed to read retry response: {}", e))?;
-        (retry_status, retry_body, new_token)
-    } else {
-        let body = response
-            .text()
-            .await
-            .map_err(|e| format!("Failed to read Claude OAuth response body: {}", e))?;
-        (initial_status, body, access_token.to_string())
-    };
+            let retry_status = retry_response.status();
+            let retry_after = if retry_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                extract_retry_after(&retry_response)
+            } else {
+                None
+            };
+            let retry_body = retry_response
+                .text()
+                .await
+                .map_err(|e| FetchError::Other(format!("Failed to read retry response: {}", e)))?;
+            (retry_status, retry_body, retry_after, new_token)
+        } else {
+            let retry_after = if initial_status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                extract_retry_after(&response)
+            } else {
+                None
+            };
+            let body = response.text().await.map_err(|e| {
+                FetchError::Other(format!("Failed to read Claude OAuth response body: {}", e))
+            })?;
+            (initial_status, body, retry_after, access_token.to_string())
+        };
 
     if !status.is_success() {
         println!(
@@ -211,6 +259,14 @@ pub(crate) async fn fetch_claude_usage_impl() -> Result<ClaudeUsageData, String>
             status,
             &body[..body.len().min(500)]
         );
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            println!(
+                "[claude-usage] Rate limited. Retry-After: {:?}",
+                retry_after_secs
+            );
+            return Err(FetchError::RateLimit { retry_after_secs });
+        }
 
         // Parse error body for a user-friendly message
         if let Ok(err_val) = serde_json::from_str::<Value>(&body) {
@@ -220,24 +276,24 @@ pub(crate) async fn fetch_claude_usage_impl() -> Result<ClaudeUsageData, String>
                 .and_then(|m| m.as_str())
             {
                 if msg.contains("scope") {
-                    return Err(format!(
+                    return Err(FetchError::Other(format!(
                         "Token missing required scope. {}. Re-run `claude login` or create a token with the user:profile scope.",
                         msg
-                    ));
+                    )));
                 }
-                return Err(format!("Claude API error: {}", msg));
+                return Err(FetchError::Other(format!("Claude API error: {}", msg)));
             }
         }
 
-        return Err(format!(
+        return Err(FetchError::Other(format!(
             "Claude OAuth API returned HTTP {}. {}",
             status,
             &body[..body.len().min(200)]
-        ));
+        )));
     }
 
-    let value: Value =
-        serde_json::from_str(&body).map_err(|e| format!("Invalid Claude OAuth JSON: {}", e))?;
+    let value: Value = serde_json::from_str(&body)
+        .map_err(|e| FetchError::Other(format!("Invalid Claude OAuth JSON: {}", e)))?;
 
     let typed = serde_json::from_value::<ClaudeOAuthUsageResponse>(value.clone()).ok();
 


### PR DESCRIPTION
Implements rate limit handling for the Claude OAuth API as described in #18.

## Changes
- `FetchError` enum in `usage.rs` distinguishes rate-limit errors from generic failures
- Extracts `Retry-After` header from 429 responses before consuming the body
- Exponential backoff with jitter starting at 30s, capped at 600s
- Respects `Retry-After` header when present
- Emits `rate-limited` / `rate-limit-cleared` events for frontend status indicator

Closes #18

Generated with [Claude Code](https://claude.ai/code)